### PR TITLE
fix: failure messages now contain the actual or expected values, instead of 'undefined'

### DIFF
--- a/dist/matchers.js
+++ b/dist/matchers.js
@@ -158,8 +158,8 @@ beforeEach(function () {
         }
     };
 
-    hlp.dp = function () {
-        angular.mock.dump(arguments);
+    hlp.dp = function (x) {
+        return angular.mock.dump(arguments.length > 1 ? arguments : x);
     };
 
     String.prototype.t = function () {
@@ -685,6 +685,9 @@ beforeEach(function () {
     matchers.toBeUniqueArray = function () {
         // iterate over the array, adding unique elements to o
         var arr = this.actual, i, len = this.actual.length, o = [];
+        this.message = function () {
+            return "Expected " + hlp.dp(this.actual) + " values {0} to be unique".t(this.isNot ? "not" : "");
+        };
         for (i = 0; i < len; i += 1) {
             if (hlp.indexOf(o, arr[i]) === -1) {
                 o.push(arr[i]);
@@ -692,11 +695,6 @@ beforeEach(function () {
                 return false;
             }
         }
-
-        this.message = function () {
-            return "Expected " + hlp.dp(this.actual) + " values is not unique";
-        };
-
         return true;
     };
 
@@ -806,4 +804,7 @@ beforeEach(function () {
 
     // aliases
     this.addMatchers(matchers);
+
+    // Keep a reference to the original matchers, for tests
+    jasmine.__angular_jasmine_matchers__ = matchers;
 });

--- a/test/matchersSpec.js
+++ b/test/matchersSpec.js
@@ -1,4 +1,4 @@
-/*global describe, it, expect, afterEach, beforeEach, angular */
+/*global jasmine, describe, xdescribe, it, expect, afterEach, beforeEach, angular */
 /**
  * Created by ferron on 9/28/13.
  */
@@ -51,6 +51,83 @@ describe('Testing Custom Matchers', function () {
         expect(date).toMatchDatePart(date, 'hours');
         expect(date).toMatchDatePart(date, 'time');
     });
+
+
+    describe('messages', function () {
+        var test;
+        beforeEach(function () {
+            // Create mock "expect" matchers, to extract only the failure message, without triggering test failures.
+            function Matchers(actual, isNot) {
+                this.actual = actual;
+                this.isNot = isNot;
+            }
+
+            Matchers.prototype = {};
+            /*jslint nomen: true*/
+            angular.forEach(jasmine.__angular_jasmine_matchers__, function (method, methodName) {
+                Matchers.prototype[methodName] = function () {
+                    var result = !!(method.apply(this, arguments));
+                    if (result !== this.isNot) {
+                        this.message = null;
+                    }
+                    return this;
+                };
+            });
+            test = function (actual) {
+                var positive = new Matchers(actual, false);
+                positive.not = new Matchers(actual, true);
+                return positive;
+            };
+        });
+
+        /*jslint regexp: true*/
+
+        it("should get a message from toEqualData", function () {
+            expect(test(33).toEqualData(44).message()).toMatch(/33.*44/);
+            expect(test(33).not.toEqualData(33).message()).toMatch(/33.*not.*33/);
+        });
+
+        it("should get a message from toBeUniqueArray", function () {
+            expect(test([1, 2, 2, 2]).toBeUniqueArray().message()).toMatch(/\[.*1.*2.*2.*2.*\].*unique/);
+            expect(test([1, 2, 3, 5]).not.toBeUniqueArray().message()).toMatch(/not/);
+        });
+
+        it("should get a message from toBeSameDate", function () {
+            var date1 = new Date("2014-01-01"), date2 = new Date("2014-02-02");
+            expect(test(date1).toBeSameDate(date2).message()).toMatch(/2014-01-01.*2014-02-02/);
+            expect(test(date1).not.toBeSameDate(date1).message()).toMatch(/not/);
+        });
+
+        it("should get a message from toBeEvenNumber", function () {
+            expect(test(33).toBeEvenNumber().message()).toMatch(/33.*even/);
+            // xxx todo: implement "not" message for this matcher
+        });
+
+        it("should get a message from toBeOddNumber", function () {
+            expect(test(22).toBeOddNumber().message()).toMatch(/22.*odd/);
+            // xxx todo: implement "not" message for this matcher
+        });
+
+        it("should get a message from toBeIso8601Date", function () {
+            expect(test("NONO").toBeIso8601Date().message()).toMatch(/NONO/);
+            expect(test("2014-01-01").not.toBeIso8601Date().message()).toMatch(/2014-01-01.*not/);
+        });
+
+        it("should get a message from toBeObject", function () {
+            expect(test(11).toBeObject().message()).toMatch(/11.*Object/);
+            expect(test({}).not.toBeObject().message()).toMatch(/\{\}.*not/);
+        });
+
+        it("should get a message from toMatchDatePart", function () {
+            var date1 = new Date("2011-11-11"), date2 = new Date("2012-12-12");
+            expect(test(date1).toMatchDatePart(date2, 'date').message()).toMatch(/11.*12/);
+            expect(test(date1).toMatchDatePart(date2, 'month').message()).toMatch(/10.*11/);
+            expect(test(date1).toMatchDatePart(date2, 'year').message()).toMatch(/2011.*2012/);
+            // xxx todo: implement "not" message for this matcher
+        });
+
+    });
+
 });
 
 


### PR DESCRIPTION
Currently, all failure messages contain `undefined` instead of the actual or expected values.
Example

```
expect(3).toBeEvenNumber();
```

will display

```
Expected undefined to be an even number
```

This is due to a missing `return` of `angular.mock.dump` in `hlp.dp`.

This PR also adds unit tests to be able to check these failure messages.
